### PR TITLE
Implement --no-color support

### DIFF
--- a/tasks/mocha_phantomjs.js
+++ b/tasks/mocha_phantomjs.js
@@ -32,6 +32,11 @@ module.exports = function(grunt) {
         results        = '',
         output         = options.output || false;
 
+    // disable color if we so choose
+    if (grunt.option('color') === false) {
+        args.push('--no-color');
+    }
+
     // Check for a local install of mocha-phantomjs to use
     if (!exists(phantomjs_path)) {
       var i = module.paths.length,


### PR DESCRIPTION
We are using this for our CI process but the color codes are awful in the generated emails. This patch lets the selected color option filter through.
