### PR TITLE
Remove grunt.util._ and grunt.util.async

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,16 @@
   },
   "dependencies": {
     "mocha-phantomjs": "~3.3.x",
-    "phantomjs": "~1.9.1-0"
+    "phantomjs": "~1.9.1-0",
+    "lodash": "2.4.1",
+    "async": "~0.2"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.6.0",
-    "grunt": "~0.4.0",
+    "grunt-contrib-jshint": "~0.8.0",
+    "grunt": "~0.4.2",
     "chai": "*",
     "mocha": "*",
-    "grunt-contrib-connect": "~0.5.0"
+    "grunt-contrib-connect": "~0.7.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"

--- a/tasks/mocha_phantomjs.js
+++ b/tasks/mocha_phantomjs.js
@@ -9,9 +9,8 @@
 'use strict';
 
 module.exports = function(grunt) {
-  var util    = grunt.util,
-      // Alias for Lo-Dash
-      _       = util._,
+  var _       = require('lodash'),
+      async   = require('async'),
       path    = require("path"),
       exists  = grunt.file.exists,
       fs      = require('fs');
@@ -71,12 +70,12 @@ module.exports = function(grunt) {
         value = [value];
       }
 
-      _.each(value, function(value) {
+      value.forEach(function(value) {
         args.push([sw, value.toString()]);
       });
     });
 
-    util.async.forEachSeries(urls, function(f, next) {
+    async.eachSeries(urls, function(f, next) {
       var phantomjs = grunt.util.spawn({
         cmd: phantomjs_path,
         args: _.flatten([f].concat(args))


### PR DESCRIPTION
[grunt.util._](http://gruntjs.com/api/grunt.util#grunt.util._) and [grunt.util.async](http://gruntjs.com/api/grunt.util#grunt.util.async) are [deprecated](http://gruntjs.com/blog/2013-11-21-grunt-0.4.2-released).
So I replaced them with [lodash](https://github.com/lodash/lodash) and [async](https://github.com/caolan/async).
