### PR TITLE
add fail option independent of the output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,17 @@ The reporter that should be used. See [the supported reporters](https://github.c
 #### output
 Type: `String`  
 
-The file that the task should output the results to. If `output` is specified, the task will always complete and not throw an error code if errors are found. The CI will determine if the build failed or not.
+The file that the task should output the results to. 
 
 #### silent
 Type: `Boolean`  
 
 Setting `silent` to true will prevent the results from being printed using stdout.
 
+#### fail
+Type: `Boolean`  
+
+If `fail` is set to false (default), the task will always complete and not throw an error code if errors are found. In this case the CI will determine if the build failed or not whether through the output file or stdout. If set to true, the task will fail if there are failed tests.
 
 #### urls
 Type: `Array`  

--- a/tasks/mocha_phantomjs.js
+++ b/tasks/mocha_phantomjs.js
@@ -31,7 +31,8 @@ module.exports = function(grunt) {
         errors         = 0,
         results        = '',
         output         = options.output || false,
-        silent         = options.silent || false;
+        silent         = options.silent || false,
+        fail           = options.fail || false;
 
     if(output) {
       grunt.file.mkdir(path.dirname(output));
@@ -103,13 +104,14 @@ module.exports = function(grunt) {
       });
 
     }, function(){
-      // Fail if errors are reported and we aren't outputing to a file
-      if(!output && errors > 0) {
-        grunt.fail.warn(errors + " tests failed");
-      }
-
+    
       if(output) {
         writeStream.end();
+      }
+
+      // Fail if errors are reported and if we have indicated that we want to fail
+      if(fail && errors > 0) {
+        grunt.fail.warn(errors + " tests failed");
       }
 
       done();


### PR DESCRIPTION
I need this option to fail independent of the output option since our CI tool parses the generated report output file and needs an exit code to make the build fail. We could write this ourselves but this change does make sense in your grunt task. If would be nice if you could incorporate this change.  