### PR TITLE
Fixed issue where grunt task couldn't find pantomjs executable on Windows

### DIFF
--- a/tasks/mocha_phantomjs.js
+++ b/tasks/mocha_phantomjs.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
       for (var i = 0; i < module.paths.length; i++) {
         var absPath = path.join(module.paths[i], script);
         if (executable && process.platform === 'win32') {
-          absPath += '.cmd';
+          absPath += '.exe';
         }
         if (fs.existsSync(absPath)) {
           return absPath;
@@ -38,7 +38,7 @@ module.exports = function(grunt) {
         config           = _.extend({ useColors: true }, options.config),
         files            = this.filesSrc,
         args             = [],
-        phantomPath      = lookup('phantomjs/bin/phantomjs', true),
+        phantomPath      = lookup('phantomjs/lib/phantom/phantomjs', true),
         mochaPhantomPath = lookup('mocha-phantomjs-core/mocha-phantomjs-core.js'),
         urls             = options.urls.concat(this.filesSrc),
         done             = this.async(),


### PR DESCRIPTION
So I'm not sure if or when this issue occurred but I can no longer run grunt-mocha-phantomjs on Windows machines. When looking at the phantomjs package it actually puts the executable in a different location than what this grunt plugin was looking for. So I went ahead and updated this. This makes it work in Windows again.

Unfortunately I have no boxes at the moment (or time) to setup a VM to verify that this does or does not break nix platforms. So this should most likely not be simply merged in. If someone could verify that would be awesome otherwise I'll get a chance to possibly later in the week.