### PR TITLE
Bump version of mocha-phantomjs-core to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "async": "^1.4.0",
-    "mocha-phantomjs-core": "^1.0.0",
+    "mocha-phantomjs-core": "^1.2.0",
     "object-assign": "^4.0.1",
     "phantomjs": "^1.9.17"
   },


### PR DESCRIPTION
Some improvements have been made for mocha-phantomjs-core since it's version 1.0.0.

Increase the version used by this module accordingly.