### PR TITLE
Pass options directly to phantomjs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,6 +65,16 @@ module.exports = function (grunt) {
           src: ['test/index.html']
         }
       },
+      phantomConfig: {
+        options: {
+          phantomConfig: {
+            '--debug': true
+          }
+        },
+        files: {
+          src: ['test/index.html']
+        }
+      },
       silent: {
         options: {
           reporter: 'xunit',

--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ Absolute `http://` or `https://` urls to be passed to PhantomJS. Specified URLs 
 
 Additional arguments may be passed. See [mocha-phantomjs's](https://github.com/metaskills/mocha-phantomjs#usage) usage.
 
+#### phantomConfig
+Type: `Object`
+Default: `{}`
+
+Options to be passed directly to phantomjs. Eg:
+
+```js
+{
+    "--local-storage-path": "my/temp-phantom-files",
+    "--local-storage-quota": "20480"
+}
+```
+
+See `phantomjs -h` for more full options list.
+
 #### config
 Type: `Object`  
 Default: `{ useColors: true }`

--- a/tasks/mocha_phantomjs.js
+++ b/tasks/mocha_phantomjs.js
@@ -33,6 +33,16 @@ module.exports = function (grunt) {
         return flattened.concat.apply(flattened, arr);
       };
 
+  function objectToArgArray(obj) {
+    var args = [];
+    for (var key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        args.push(key + '=' + obj[key]);
+      }
+    }
+    return args;
+  }
+
   grunt.registerMultiTask('mocha_phantomjs', 'Run client-side mocha test with phantomjs.', function () {
     // Merge options
     var options          = this.options({
@@ -41,6 +51,7 @@ module.exports = function (grunt) {
         }),
         config           = objectAssign({ useColors: true }, options.config),
         phantomPath      = lookup('.bin/phantomjs', true),
+        phantomConfig    = objectToArgArray(options.phantomConfig || []),
         mochaPhantomPath = lookup('mocha-phantomjs-core/mocha-phantomjs-core.js'),
         urls             = options.urls.concat(this.filesSrc),
         done             = this.async(),
@@ -61,9 +72,12 @@ module.exports = function (grunt) {
     }
 
     async.eachSeries(urls, function (f, next) {
+
+      var args = phantomConfig.concat(flatten([mochaPhantomPath, f, options.reporter, JSON.stringify(config)]));
+
       var phantomjs = grunt.util.spawn({
         cmd: phantomPath,
-        args: flatten([mochaPhantomPath, f, options.reporter, JSON.stringify(config)])
+        args: args
       }, function () {
         next();
       });

--- a/tasks/mocha_phantomjs.js
+++ b/tasks/mocha_phantomjs.js
@@ -33,9 +33,11 @@ module.exports = function (grunt) {
         return flattened.concat.apply(flattened, arr);
       };
 
-  function objectToArgArray(obj) {
-    var args = [];
-    for (var key in obj) {
+  function objectToArgArray (obj) {
+    var key,
+        args = [];
+
+    for (key in obj) {
       if (obj.hasOwnProperty(key)) {
         args.push(key + '=' + obj[key]);
       }
@@ -72,10 +74,12 @@ module.exports = function (grunt) {
     }
 
     async.eachSeries(urls, function (f, next) {
+      var args,
+          phantomjs;
 
-      var args = phantomConfig.concat(flatten([mochaPhantomPath, f, options.reporter, JSON.stringify(config)]));
+      args = phantomConfig.concat(flatten([mochaPhantomPath, f, options.reporter, JSON.stringify(config)]));
 
-      var phantomjs = grunt.util.spawn({
+      phantomjs = grunt.util.spawn({
         cmd: phantomPath,
         args: args
       }, function () {


### PR DESCRIPTION
Add new option phantomConfig that can be used to pass arguments directly to phantomjs, for example the "--local-storage-path" option or "--cookies-file", etc