### PR TITLE
Updating phantom versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "async": "^1.4.0",
-    "mocha-phantomjs-core": "^1.0.0",
+    "mocha-phantomjs-core": "1.3.0",
     "object-assign": "^4.0.1",
-    "phantomjs": "1.9.1 - 1.9.7-15"
+    "phantomjs-prebuilt": "2.1.3" 
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
Bumping these allowed me to run this with node 4.x

Without it I was getting this error:

    Running "mocha_phantomjs:dist" (mocha_phantomjs) task

    internal/child_process.js:274
          var err = this._handle.spawn(options);