### PR TITLE
NPM: upgrade modules and require Grunt 1.0.0 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,21 +9,21 @@
   "dependencies": {
     "async": "^1.5.2",
     "mocha-phantomjs-core": "^1.3.0",
-    "object-assign": "^4.0.1",
+    "object-assign": "^4.1.0",
     "phantomjs-prebuilt": "^2.1.3"
   },
   "devDependencies": {
-    "chai": "^3.2.0",
-    "eslint": "^1.3.1",
-    "eslint-config-standard": "^4.1.0",
+    "chai": "^3.5.0",
+    "eslint": "^2.13.1",
+    "eslint-config-standard": "^5.3.0",
     "eslint-plugin-standard": "^1.3.0",
-    "grunt-contrib-connect": "^0.11.2",
-    "grunt-contrib-jshint": "^0.11.2",
-    "grunt-eslint": "^17.1.0",
-    "mocha": "^2.3.0"
+    "grunt-contrib-connect": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-eslint": "^18.1.0",
+    "mocha": "^2.5.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": "~1.0.0"
   },
   "scripts": {
     "test": "grunt"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "chai": "^3.5.0",
     "eslint": "^2.13.1",
     "eslint-config-standard": "^5.3.0",
+    "eslint-plugin-promise": "^1.3.0",
     "eslint-plugin-standard": "^1.3.0",
     "grunt-contrib-connect": "^1.0.0",
     "grunt-contrib-jshint": "^1.0.0",

--- a/tasks/mocha_phantomjs.js
+++ b/tasks/mocha_phantomjs.js
@@ -12,26 +12,28 @@ module.exports = function (grunt) {
   var objectAssign = require('object-assign'),
       async        = require('async'),
       path         = require('path'),
-      fs           = require('fs'),
-      lookup       = function (script, executable) {
-        var i = 90,
-            absPath;
+      fs           = require('fs');
 
-        for (i = 0; i < module.paths.length; i++) {
-          absPath = path.join(module.paths[i], script);
-          if (executable && process.platform === 'win32') {
-            absPath += '.cmd';
-          }
-          if (fs.existsSync(absPath)) {
-            return absPath;
-          }
-        }
-        grunt.fail.warn('Unable to find ' + script);
-      },
-      flatten       = function (arr) {
-        var flattened = [];
-        return flattened.concat.apply(flattened, arr);
-      };
+  function lookup (script, executable) {
+    var i = 90,
+        absPath;
+
+    for (i = 0; i < module.paths.length; i++) {
+      absPath = path.join(module.paths[i], script);
+      if (executable && process.platform === 'win32') {
+        absPath += '.cmd';
+      }
+      if (fs.existsSync(absPath)) {
+        return absPath;
+      }
+    }
+    grunt.fail.warn('Unable to find ' + script);
+  };
+
+  function flatten (arr) {
+    var flattened = [];
+    return flattened.concat.apply(flattened, arr);
+  };
 
   function objectToArgArray (obj) {
     var key,


### PR DESCRIPTION
In order to get ESLint to pass I had to switch the
`lookup` and `flatten` functions to standard function declarations
instead of saving anonymous functions into variables.